### PR TITLE
Update URL formats for hashtags and lists

### DIFF
--- a/ttp/tests.py
+++ b/ttp/tests.py
@@ -356,22 +356,22 @@ class TWPTests(unittest.TestCase):
     # --------------------------------------------------------------------------
     def test_hashtag_followed_full_whitespace(self):
         result = self.parser.parse('#hashtag　text')
-        self.assertEqual(result.html, '<a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>　text')
+        self.assertEqual(result.html, '<a href="https://twitter.com/hashtag/%23hashtag">#hashtag</a>　text')
         self.assertEqual(result.tags, ['hashtag'])
 
     def test_hashtag_followed_full_hash(self):
         result = self.parser.parse('＃hashtag')
-        self.assertEqual(result.html, '<a href="https://twitter.com/search?q=%23hashtag">＃hashtag</a>')
+        self.assertEqual(result.html, '<a href="https://twitter.com/hashtag/%23hashtag">＃hashtag</a>')
         self.assertEqual(result.tags, ['hashtag'])
 
     def test_hashtag_preceeded_full_whitespace(self):
         result = self.parser.parse('text　#hashtag')
-        self.assertEqual(result.html, 'text　<a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>')
+        self.assertEqual(result.html, 'text　<a href="https://twitter.com/hashtag/%23hashtag">#hashtag</a>')
         self.assertEqual(result.tags, ['hashtag'])
 
     def test_hashtag_number(self):
         result = self.parser.parse('text #1tag')
-        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%231tag">#1tag</a>')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/hashtag/%231tag">#1tag</a>')
         self.assertEqual(result.tags, ['1tag'])
 
     def test_not_hashtag_escape(self):
@@ -381,27 +381,27 @@ class TWPTests(unittest.TestCase):
 
     def test_hashtag_japanese(self):
         result = self.parser.parse('text #hashtagの')
-        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>の')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/hashtag/%23hashtag">#hashtag</a>の')
         self.assertEqual(result.tags, ['hashtag'])
 
     def test_hashtag_period(self):
         result = self.parser.parse('text.#hashtag')
-        self.assertEqual(result.html, 'text.<a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>')
+        self.assertEqual(result.html, 'text.<a href="https://twitter.com/hashtag/%23hashtag">#hashtag</a>')
         self.assertEqual(result.tags, ['hashtag'])
 
     def test_hashtag_trailing(self):
         result = self.parser.parse('text #hashtag')
-        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/hashtag/%23hashtag">#hashtag</a>')
         self.assertEqual(result.tags, ['hashtag'])
 
     def test_not_hashtag_exclamation(self):
         result = self.parser.parse('text #hashtag!')
-        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>!')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/hashtag/%23hashtag">#hashtag</a>!')
         self.assertEqual(result.tags, ['hashtag'])
 
     def test_hashtag_multiple(self):
         result = self.parser.parse('text #hashtag1 #hashtag2')
-        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hashtag1">#hashtag1</a> <a href="https://twitter.com/search?q=%23hashtag2">#hashtag2</a>')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/hashtag/%23hashtag1">#hashtag1</a> <a href="https://twitter.com/hashtag/%23hashtag2">#hashtag2</a>')
         self.assertEqual(result.tags, ['hashtag1', 'hashtag2'])
 
     def test_not_hashtag_number(self):
@@ -416,17 +416,17 @@ class TWPTests(unittest.TestCase):
 
     def test_hashtag_umlaut(self):
         result = self.parser.parse('text #hash_tagüäö')
-        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hash_tag%C3%BC%C3%A4%C3%B6">#hash_tagüäö</a>')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/hashtag/%23hash_tag%C3%BC%C3%A4%C3%B6">#hash_tagüäö</a>')
         self.assertEqual(result.tags, ['hash_tag\xfc\xe4\xf6'])
 
     def test_hashtag_alpha(self):
         result = self.parser.parse('text #hash0tag')
-        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hash0tag">#hash0tag</a>')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/hashtag/%23hash0tag">#hash0tag</a>')
         self.assertEqual(result.tags, ['hash0tag'])
 
     def test_hashtag_under(self):
         result = self.parser.parse('text #hash_tag')
-        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hash_tag">#hash_tag</a>')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/hashtag/%23hash_tag">#hash_tag</a>')
         self.assertEqual(result.tags, ['hash_tag'])
 
     # Username tests -----------------------------------------------------------
@@ -515,22 +515,22 @@ class TWPTests(unittest.TestCase):
     # --------------------------------------------------------------------------
     def test_list_preceeded(self):
         result = self.parser.parse('text @username/list')
-        self.assertEqual(result.html, 'text <a href="https://twitter.com/username/list">@username/list</a>')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/username/lists/list">@username/list</a>')
         self.assertEqual(result.lists, [('username', 'list')])
 
     def test_list_beginning(self):
         result = self.parser.parse('@username/list')
-        self.assertEqual(result.html, '<a href="https://twitter.com/username/list">@username/list</a>')
+        self.assertEqual(result.html, '<a href="https://twitter.com/username/lists/list">@username/list</a>')
         self.assertEqual(result.lists, [('username', 'list')])
 
     def test_list_preceeded_punctuation(self):
         result = self.parser.parse('.@username/list')
-        self.assertEqual(result.html, '.<a href="https://twitter.com/username/list">@username/list</a>')
+        self.assertEqual(result.html, '.<a href="https://twitter.com/username/lists/list">@username/list</a>')
         self.assertEqual(result.lists, [('username', 'list')])
 
     def test_list_followed_punctuation(self):
         result = self.parser.parse('@username/list&^$%^')
-        self.assertEqual(result.html, '<a href="https://twitter.com/username/list">@username/list</a>&^$%^')
+        self.assertEqual(result.html, '<a href="https://twitter.com/username/lists/list">@username/list</a>&^$%^')
         self.assertEqual(result.lists, [('username', 'list')])
 
     def test_list_not_slash_space(self):
@@ -541,7 +541,7 @@ class TWPTests(unittest.TestCase):
 
     def test_list_beginning2(self):
         result = self.parser.parse('@username/list')
-        self.assertEqual(result.html, '<a href="https://twitter.com/username/list">@username/list</a>')
+        self.assertEqual(result.html, '<a href="https://twitter.com/username/lists/list">@username/list</a>')
         self.assertEqual(result.lists, [('username', 'list')])
 
     def test_list_not_empty_username(self):
@@ -557,12 +557,12 @@ class TWPTests(unittest.TestCase):
     def test_list_long_truncate(self):
         result = self.parser.parse('@username/list5678901234567890123456789012345678901234567890123456789012345678901234567890A')
         self.assertEqual(
-            result.html, '<a href="https://twitter.com/username/list5678901234567890123456789012345678901234567890123456789012345678901234567890">@username/list5678901234567890123456789012345678901234567890123456789012345678901234567890</a>A')
+            result.html, '<a href="https://twitter.com/username/lists/list5678901234567890123456789012345678901234567890123456789012345678901234567890">@username/list5678901234567890123456789012345678901234567890123456789012345678901234567890</a>A')
         self.assertEqual(result.lists, [('username', 'list5678901234567890123456789012345678901234567890123456789012345678901234567890')])
 
     def test_list_with_dash(self):
         result = self.parser.parse('text @username/list-foo')
-        self.assertEqual(result.html, 'text <a href="https://twitter.com/username/list-foo">@username/list-foo</a>')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/username/lists/list-foo">@username/list-foo</a>')
         self.assertEqual(result.lists, [('username', 'list-foo')])
 
 

--- a/ttp/ttp.py
+++ b/ttp/ttp.py
@@ -270,7 +270,7 @@ class Parser(object):
     # User defined formatters --------------------------------------------------
     def format_tag(self, tag, text):
         '''Return formatted HTML for a hashtag.'''
-        return '<a href="https://twitter.com/search?q=%s">%s%s</a>' \
+        return '<a href="https://twitter.com/hashtag/%s">%s%s</a>' \
             % (quote(('#' + text).encode('utf-8')), tag, text)
 
     def format_username(self, at_char, user):
@@ -280,7 +280,7 @@ class Parser(object):
 
     def format_list(self, at_char, user, list_name):
         '''Return formatted HTML for a list.'''
-        return '<a href="https://twitter.com/%s/%s">%s%s/%s</a>' \
+        return '<a href="https://twitter.com/%s/lists/%s">%s%s/%s</a>' \
                % (user, list_name, at_char, user, list_name)
 
     def format_url(self, url, text):


### PR DESCRIPTION
Hi @edburnett,

I have noticed that the URLs used for hashtags and lists have changed over time. For instance, hashtags are now located at: `https://twitter.com/hashtag/%23hashtag`, and lists at: `https://twitter.com/username/lists/some-list`.

Even if the old URLs still work (in some way), I make this pull request to update the URL formats so they match the new ones. :-)
